### PR TITLE
Fix broken tests; add flake8 linting support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN \
           curl \
       && pip install --no-cache \
           pytest \
-          requests_mock \
+          pytest-flake8 \
+          httpretty \
       && curl -s "https://raw.githubusercontent.com/apex/apex/master/install.sh" | sh \
       && apk del .build-deps
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,6 @@ deploy: build
 			-s COFFEE_BUTTON_SLACK_CHANNEL="$(COFFEE_BUTTON_SLACK_CHANNEL)"
 
 test: build
-	docker run --rm coffee-button:slack py.test
+	docker run --rm coffee-button:slack py.test --flake8
 
 .PHONY: build deploy test

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ make test
 
 ## Deployment
 
-Function deployment will occurs automatically via Travis CI. If you choose to execute deployments manually, execute the following steps:
+Function deployment occurs automatically via Travis CI. If you choose to execute deployments manually, run through the following steps:
 
 ```bash
 $ export COFFEE_BUTTON_SLACK_WEBHOOK_URL="https://hooks.slack.com/..."

--- a/functions/Slack/main.py
+++ b/functions/Slack/main.py
@@ -30,12 +30,12 @@ def handle(event, context):
         requests.post(slack_webhook_url, json={
             'text': 'Coffee is brewing and will be ready in about 5 minutes!',
             'channel': slack_channel})
-            
+
     if event['clickType'] == str(ButtonClickType.Double):
         requests.post(slack_webhook_url, json={
-            'text': 'Threat Level Jack-O-Lantern! I repeat: Threat Level Jack-O-Lantern. We are out of coffee.',
+            'text': 'Threat Level Jack-O-Lantern! I repeat: Threat Level Jack-O-Lantern. We are out of coffee.',  # NOQA
             'channel': slack_channel})
-            
+
     if event['clickType'] == str(ButtonClickType.Long):
         requests.post(slack_webhook_url, json={
             'text': 'Fresh coffee is ready!',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[pytest]
+flake8-ignore =
+    functions/Slack/enum* ALL
+    functions/Slack/requests* ALL

--- a/tests/test_coffee_button.py
+++ b/tests/test_coffee_button.py
@@ -1,32 +1,42 @@
 import os
-import requests_mock
+import json
+import httpretty
 import unittest
-
 
 from functions.Slack.main import handle, ButtonClickType
 
 
 class SlackTestCase(unittest.TestCase):
-    """Test that Candidate parsing works correctly"""
+    """Test processing of IoT button states"""
 
-    @classmethod
-    def setUpClass(self):
+    def setUp(self):
         self.slack_webhook_url = "https://hooks.slack.com/test"
         self.slack_channel = '#test'
-        self.mock = requests_mock.Mocker()
-        self.mock.post(self.slack_webhook_url)
 
         os.environ['COFFEE_BUTTON_SLACK_WEBHOOK_URL'] = self.slack_webhook_url
         os.environ['COFFEE_BUTTON_SLACK_CHANNEL'] = self.slack_channel
 
+        httpretty.enable()
+        httpretty.register_uri(httpretty.POST, self.slack_webhook_url)
+
+    def tearDown(self):
+        httpretty.disable()
+        httpretty.reset()
+
     def test_single_click_type(self):
         handle({'clickType': str(ButtonClickType.Single)}, None)
-        self.assertEquals(self.mock.call_count, 1)
+        self.assertTrue(httpretty.has_request())
+        self.assertTrue("brewing" in json.loads(
+            httpretty.last_request().body)['text'])
 
-    def test_single_click_type(self):
+    def test_double_click_type(self):
         handle({'clickType': str(ButtonClickType.Double)}, None)
-        self.assertEquals(self.mock.call_count, 0)
+        self.assertTrue(httpretty.has_request())
+        self.assertTrue("Jack-O-Lantern" in json.loads(
+            httpretty.last_request().body)['text'])
 
-    def test_single_click_type(self):
+    def test_long_click_type(self):
         handle({'clickType': str(ButtonClickType.Long)}, None)
-        self.assertEquals(self.mock.call_count, 0)
+        self.assertTrue(httpretty.has_request())
+        self.assertTrue("ready" in json.loads(
+            httpretty.last_request().body)['text'])


### PR DESCRIPTION
All test functions had the same name, so only the last one was being executed. In addition, `requests_mock` didn't seem to be working at all and was only reporting false positives.

`httpretty` works against the Python standard library `socket` module, which works with `requests`.

---

**Testing**

Change the condition in `main.py` to trigger on another `ButtonClickType` and execute the test suite:

``` bash
$ make test
```
