### PR TITLE
Add time to brewing message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN \
           pytest \
           pytest-flake8 \
           httpretty \
+          pytz \
       && curl -s "https://raw.githubusercontent.com/apex/apex/master/install.sh" | sh \
       && apk del .build-deps
 
@@ -18,4 +19,5 @@ COPY . /usr/src
 RUN \
       pip install --no-cache -t functions/Slack \
           enum34 \
-          requests
+          requests \
+          pytz

--- a/functions/Slack/main.py
+++ b/functions/Slack/main.py
@@ -1,5 +1,7 @@
 import os
 import requests
+import pytz
+import datetime
 
 from enum import Enum
 
@@ -27,8 +29,10 @@ def handle(event, context):
     slack_channel = os.environ['COFFEE_BUTTON_SLACK_CHANNEL']
 
     if event['clickType'] == str(ButtonClickType.Single):
+        now = datetime.datetime.now(tz=pytz.timezone('US/Eastern'))
+        ready_time = now + datetime.timedelta(minutes=5)
         requests.post(slack_webhook_url, json={
-            'text': 'Coffee is brewing and will be ready in about 5 minutes!',
+            'text': 'Coffee is brewing and will be ready at {}!'.format(ready_time.strftime('%-I:%M%p')),  # NOQA
             'channel': slack_channel})
 
     if event['clickType'] == str(ButtonClickType.Double):

--- a/functions/Slack/main.py
+++ b/functions/Slack/main.py
@@ -30,9 +30,10 @@ def handle(event, context):
 
     if event['clickType'] == str(ButtonClickType.Single):
         now = datetime.datetime.now(tz=pytz.timezone('US/Eastern'))
-        ready_time = now + datetime.timedelta(minutes=5)
+        ready_datetime = now + datetime.timedelta(minutes=5)
+        ready_time = ready_datetime.strftime('%l:%M%p').lower().strip()
         requests.post(slack_webhook_url, json={
-            'text': 'Coffee is brewing and will be ready at {}!'.format(ready_time.strftime('%-I:%M%p')),  # NOQA
+            'text': 'Coffee is brewing and will be ready at {}!'.format(ready_time),  # NOQA
             'channel': slack_channel})
 
     if event['clickType'] == str(ButtonClickType.Double):

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,4 @@
 flake8-ignore =
     functions/Slack/enum* ALL
     functions/Slack/requests* ALL
+    functions/Slack/pytz* ALL


### PR DESCRIPTION
The status channel being mostly the same exact message makes my eyes
glaze over a bit when I check it, plus it takes a tiny amount of mental
effort to read the little timestamp and add five minutes to it. So this
changes the brewing message to say what time it will be ready.
