### PR TITLE
Update double click message

### DIFF
--- a/functions/Slack/main.py
+++ b/functions/Slack/main.py
@@ -38,7 +38,7 @@ def handle(event, context):
 
     if event['clickType'] == str(ButtonClickType.Double):
         requests.post(slack_webhook_url, json={
-            'text': 'Threat Level Jack-O-Lantern! I repeat: Threat Level Jack-O-Lantern. We are out of coffee.',  # NOQA
+            'text': 'I was rushing to a meeting, and polished off the last of the brewed coffee, wish I had time to make another pot, but alas, I do not. Sorry, we are out of brewed coffee.',  # NOQA
             'channel': slack_channel})
 
     if event['clickType'] == str(ButtonClickType.Long):

--- a/functions/Slack/main.py
+++ b/functions/Slack/main.py
@@ -38,7 +38,7 @@ def handle(event, context):
 
     if event['clickType'] == str(ButtonClickType.Double):
         requests.post(slack_webhook_url, json={
-            'text': 'I was rushing to a meeting, and polished off the last of the brewed coffee, wish I had time to make another pot, but alas, I do not. Sorry, we are out of brewed coffee.',  # NOQA
+            'text': 'Oh no! The pot is empty but my meeting is starting! Oops and sorry',  # NOQA
             'channel': slack_channel})
 
     if event['clickType'] == str(ButtonClickType.Long):

--- a/tests/test_coffee_button.py
+++ b/tests/test_coffee_button.py
@@ -32,7 +32,7 @@ class SlackTestCase(unittest.TestCase):
     def test_double_click_type(self):
         handle({'clickType': str(ButtonClickType.Double)}, None)
         self.assertTrue(httpretty.has_request())
-        self.assertTrue("Jack-O-Lantern" in json.loads(
+        self.assertTrue("Oops and sorry" in json.loads(
             httpretty.last_request().body)['text'])
 
     def test_long_click_type(self):


### PR DESCRIPTION
I think it's best to `@` the person who is responsible for purchasing new coffee when we are down to the last bag.

This was discussed here:
https://azavea.slack.com/archives/C03NFSGUL/p1528300206000878

The double-click message seems much more useful to indicate that we are just out of brewed coffee. 

This PR just makes that change in wording for the double click.